### PR TITLE
feat: Add start parameter to YouTube shortcode

### DIFF
--- a/layouts/_shortcodes/youtube.html
+++ b/layouts/_shortcodes/youtube.html
@@ -1,13 +1,14 @@
-{{- $videoID := (.Get 0 | htmlEscape | safeURL) -}}
+{{- $videoID := .Get "id" | htmlEscape | safeURL -}}
+{{- $startTime := .Get "start" -}}
 {{- $validID := findRE "^[\\w-]{11}$" $videoID -}}
 {{- if gt (len $validID) 0 -}}
 <a
-  href="https://youtu.be/{{ $videoID }}"
+  href="https://youtu.be/{{ $videoID }}{{ with $startTime }}&t={{ . }}{{ end }}"
   rel="noopener noreferrer"
   target="_blank"
   class="yt-thumbnail"
 >
-  <img 
+  <img
     src="https://img.youtube.com/vi/{{ $videoID }}/hqdefault.jpg"
     alt="YouTube video thumbnail"
     loading="lazy"


### PR DESCRIPTION
This pull request enhances the youtube shortcode by adding an optional start parameter. This allows content creators to embed a YouTube video that begins playback at a specific timestamp.

Changes Made

Modified layouts/partials/_shortcodes/youtube.html to accept a new named parameter: start.

The shortcode now uses only named parameters (id and start) to avoid issues with mixing parameter types.

If the start parameter is provided, the shortcode appends the corresponding timestamp (e.g., &t=38) to the video URL.